### PR TITLE
Unit 6: Form Recognizer | Converted to PowerShell

### DIFF
--- a/form-recognizer.ps1
+++ b/form-recognizer.ps1
@@ -1,13 +1,11 @@
-$endpoint="YOUR_ENDPOINT"
-$key="YOUR_KEY"
+$endpoint="ENDPOINT"
+$key="KEY"
 
 # For this unit, there is only one sample receipt image
 $img_file = "receipt.jpg"
 
 # Create the URL where the raw receipt image can be found
-$img = "https://raw.githubusercontent.com/GraemeMalcolm/ai-stuff/main/data/vision/$img_file"
-
-Write-Host $img
+$img = "https://github.com/GraemeMalcolm/ai-stuff/raw/main/data/vision/$img_file"
 
 # Create the header for the REST POST with the subscription key
 # In this example, the URL of the image will be sent instead of 
@@ -22,28 +20,30 @@ $body = "{ 'source': '$img' }"
 # Call the receipt analyze method with the header and body
 Write-Host "Analyzing receipt..."
 $result = Invoke-RestMethod -Method Post `
-          -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=true&locale=en-US" `
+          -Uri "$endpoint/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze" `
           -Headers $headers `
-          -Body $body | ConvertTo-Json -Depth 10
-Write-Host "...Done`n"
+          -Body $body | ConvertTo-Json -Depth 6 
+
+$analysis = $result | ConvertFrom-Json
+#Write-Host "type: $($analysis.GetType())"
+#Write-Host "resultID : $($analysis.headers["operation-location"])`n"
 
 # Extract the resultID from the response of the receipt anaylzer
-# TODO
-$resultID = 0
+
 
 # Create the header for the REST POST with the subscription key
-$resultHeaders = @{}
-$resultHeaders.Add( "Ocp-Apim-Subscription-Key", $key )
+# $resultHeaders = @{}
+# $resultHeaders.Add( "Ocp-Apim-Subscription-Key", $key )
 
-# Get the receipt analysis results, passing in the resultID
-Write-Host "Getting results..."
-$result = Invoke-RestMethod -Method Get `
-          -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyzeResults/$resultID" `
-          -Headers $resultHeaders | ConvertTo-Json -Depth 10
-Write-Host "...Done`n"
+# # Get the receipt analysis results, passing in the resultID
+# Write-Host "Getting results..."
+# $result = Invoke-RestMethod -Method Get `
+#           -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyzeResults/$resultID" `
+#           -Headers $resultHeaders | ConvertTo-Json -Depth 10
+# Write-Host "...Done`n"
 
-# Get the object of the receipt analysis results
-$analysis = ($result | ConvertFrom-Json)
+# # Get the object of the receipt analysis results
+# $analysis = ($result | ConvertFrom-Json)
 
 # Print out all of the properties of the receipt analysis
 # TODO

--- a/form-recognizer.ps1
+++ b/form-recognizer.ps1
@@ -1,0 +1,49 @@
+$endpoint="YOUR_ENDPOINT"
+$key="YOUR_KEY"
+
+# For this unit, there is only one sample receipt image
+$img_file = "receipt.jpg"
+
+# Create the URL where the raw receipt image can be found
+$img = "https://raw.githubusercontent.com/GraemeMalcolm/ai-stuff/main/data/vision/$img_file"
+
+Write-Host $img
+
+# Create the header for the REST POST with the subscription key
+# In this example, the URL of the image will be sent instead of 
+# the raw image, so the Content-Type is JSON
+$headers = @{}
+$headers.Add( "Ocp-Apim-Subscription-Key", $key )
+$headers.Add( "Content-Type","application/json" )
+
+# Create the body with the URL of the raw image
+$body = "{ 'source': '$img' }"
+
+# Call the receipt analyze method with the header and body
+Write-Host "Analyzing receipt..."
+$result = Invoke-RestMethod -Method Post `
+          -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyze?includeTextDetails=true&locale=en-US" `
+          -Headers $headers `
+          -Body $body | ConvertTo-Json -Depth 10
+Write-Host "...Done`n"
+
+# Extract the resultID from the response of the receipt anaylzer
+# TODO
+$resultID = 0
+
+# Create the header for the REST POST with the subscription key
+$resultHeaders = @{}
+$resultHeaders.Add( "Ocp-Apim-Subscription-Key", $key )
+
+# Get the receipt analysis results, passing in the resultID
+Write-Host "Getting results..."
+$result = Invoke-RestMethod -Method Get `
+          -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyzeResults/$resultID" `
+          -Headers $resultHeaders | ConvertTo-Json -Depth 10
+Write-Host "...Done`n"
+
+# Get the object of the receipt analysis results
+$analysis = ($result | ConvertFrom-Json)
+
+# Print out all of the properties of the receipt analysis
+# TODO

--- a/form-recognizer.ps1
+++ b/form-recognizer.ps1
@@ -1,11 +1,8 @@
-$endpoint="ENDPOINT"
-$key="KEY"
-
-# For this unit, there is only one sample receipt image
-$img_file = "receipt.jpg"
+$endpoint="YOUR_ENDPOINT"
+$key="YOUR_KEY"
 
 # Create the URL where the raw receipt image can be found
-$img = "https://github.com/GraemeMalcolm/ai-stuff/raw/main/data/vision/$img_file"
+$img = "https://raw.githubusercontent.com/GraemeMalcolm/ai-stuff/main/data/vision/receipt.jpg"
 
 # Create the header for the REST POST with the subscription key
 # In this example, the URL of the image will be sent instead of 
@@ -15,35 +12,57 @@ $headers.Add( "Ocp-Apim-Subscription-Key", $key )
 $headers.Add( "Content-Type","application/json" )
 
 # Create the body with the URL of the raw image
-$body = "{ 'source': '$img' }"
+$body = "{'source': '$img'}"
 
 # Call the receipt analyze method with the header and body
-Write-Host "Analyzing receipt..."
-$result = Invoke-RestMethod -Method Post `
-          -Uri "$endpoint/formrecognizer/v2.1-preview.2/prebuilt/receipt/analyze" `
+# Must call the Invoke-WebRequest to have acces to the header
+Write-Host "Sending receipt..."
+$response = Invoke-WebRequest -Method Post `
+          -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyze" `
           -Headers $headers `
-          -Body $body | ConvertTo-Json -Depth 6 
+          -Body $body
+Write-Host "...Receipt sent."
 
-$analysis = $result | ConvertFrom-Json
-#Write-Host "type: $($analysis.GetType())"
-#Write-Host "resultID : $($analysis.headers["operation-location"])`n"
+# Extract the URL from the response of the receipt anaylzer 
+# to call the API to getting the analysis results
+$resultUrl = $($response.Headers['Operation-Location'])
 
-# Extract the resultID from the response of the receipt anaylzer
+# Create the header for the REST GET with only the subscription key
+$resultHeaders = @{}
+$resultHeaders.Add( "Ocp-Apim-Subscription-Key", $key )
 
+# Get the receipt analysis results, passing in the resultURL
+# Continue to request results until the analysis is "succeeded"
+Write-Host "Getting results..."
+Do {
+    $result = Invoke-RestMethod -Method Get `
+            -Uri $resultUrl `
+            -Headers $resultHeaders | ConvertTo-Json -Depth 10
 
-# Create the header for the REST POST with the subscription key
-# $resultHeaders = @{}
-# $resultHeaders.Add( "Ocp-Apim-Subscription-Key", $key )
+    $analysis = ($result | ConvertFrom-Json)
+} while ($analysis.status -ne "succeeded")
+Write-Host "...Done`n"
 
-# # Get the receipt analysis results, passing in the resultID
-# Write-Host "Getting results..."
-# $result = Invoke-RestMethod -Method Get `
-#           -Uri "$endpoint/formrecognizer/v2.1/prebuilt/receipt/analyzeResults/$resultID" `
-#           -Headers $resultHeaders | ConvertTo-Json -Depth 10
-# Write-Host "...Done`n"
-
-# # Get the object of the receipt analysis results
-# $analysis = ($result | ConvertFrom-Json)
+# Access the relevant fields from the analysis 
+$analysisFields = $analysis.analyzeResult.documentResults.fields
 
 # Print out all of the properties of the receipt analysis
-# TODO
+Write-Host ("Receipt Type: ", $($analysisFields.fields.ReceiptType.valueString))
+Write-Host ("Merchant Address: ", $($analysisFields.fields.MerchantAddress.valueString))
+Write-Host ("Merchant Phone: ", $($analysisFields.MerchantPhoneNumber.valueString))
+Write-Host ("Transaction Date: ", $($analysisFields.TransactionDate.valueString))
+Write-Host ("Receipt Items: ")
+
+# Access the individual items from the analysis
+$receiptItems = $($analysisFields.fields.Items.valueArray)
+
+for (($idx = 0); $idx -lt $receiptItems.Length; $idx++) {
+    $item = $receiptItems[$idx] 
+    Write-Host ("Item #", ($idx+1))
+    Write-Host ("  - Name: ", $($item.valueObject.Name.valueString))
+    Write-Host ("  - Price: ",$($item.valueObject.TotalPrice.valueNumber))
+}
+
+Write-Host ("Subtotal: ", $($analysisFields.Subtotal.valueNumber))
+Write-Host ("Tax: ", $($analysisFields.Tax.valueNumber))
+Write-Host ("Total: ", $($analysisFields.Total.valueNumber))


### PR DESCRIPTION
This one is complete. The issue we found with needing to call two different API methods:
- [Analyze Receipt](https://westus.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-1/operations/AnalyzeReceiptAsync)
- [Get Analyze Receipt Result](https://westus.dev.cognitive.microsoft.com/docs/services/form-recognizer-api-v2-1/operations/GetAnalyzeReceiptResult)

The first call returns an empty response, but with a header that we needed to access for the purposes of getting the correct `resultID` for the image we submitted to Azure for analysis. `Invoke-RestMethod` does not give a result with access to the header, so we had to modify it to `Invoke-WebRequest`.

From there it was a matter of extracting the correct fields.

✋ *High Five* 